### PR TITLE
fix(firefox): tried to deal with appearance of tree-styled tabs

### DIFF
--- a/Firefox/Vertex-Dark/chrome/userChrome.css
+++ b/Firefox/Vertex-Dark/chrome/userChrome.css
@@ -117,8 +117,6 @@
   background-color: rgba(0,0,0,0) !important;
   color: #A7A7A8 !important;
   text-shadow: 0 -1px rgba(0,0,0,0.7) !important;
-  -moz-margin-end: 0 !important;
-  -moz-margin-start: 0 !important;
 }
 
 /*Active tab */

--- a/Firefox/Vertex-Light/chrome/userChrome.css
+++ b/Firefox/Vertex-Light/chrome/userChrome.css
@@ -120,8 +120,6 @@
   background-color: rgba(0,0,0,0) !important;
   color: #818182 !important;
   text-shadow: 0 1px rgba(255,255,255,0.95) !important;
-  -moz-margin-end: 0 !important;
-  -moz-margin-start: 0 !important;
 }
 
 /*Active tab */

--- a/Firefox/Vertex/chrome/userChrome.css
+++ b/Firefox/Vertex/chrome/userChrome.css
@@ -117,8 +117,6 @@
   background-color: rgba(0,0,0,0) !important;
   color: #A7A7A8 !important;
   text-shadow: 0 -1px rgba(0,0,0,0.7) !important;
-  -moz-margin-end: 0 !important;
-  -moz-margin-start: 0 !important;
 }
 
 /*Active tab */


### PR DESCRIPTION
this PR solves the problem when with Tree Style Tab extension all tabs have the same left margin (instead of representing tree deepness with bigger margin)

i tried to test it with default tab appearance and did not noticed any problems, but i still not totally sure so please check it very carefully
