### PR TITLE
fix window not flashing on alerts

### DIFF
--- a/common/cinnamon/cinnamon.css
+++ b/common/cinnamon/cinnamon.css
@@ -1380,6 +1380,7 @@ StScrollBar StButton#vhandle:active {
 }
 
 .window-list-item-demands-attention {
+  border-image: none;
   background-gradient-start: rgba(255,52,52,0.5);
   background-gradient-end: rgba(255,144,144,0.5);
 }


### PR DESCRIPTION
Noticed that taskbar wasn't flashing on window alerts, adding border-image: none; to .window-list-item-demands-attention fixes it for me.