### PR TITLE
Fix Posix shell compatibility of the configure script

### DIFF
--- a/m4/vertex-enable.m4
+++ b/m4/vertex-enable.m4
@@ -9,11 +9,11 @@ AC_DEFUN([VERTEX_ENABLE], [
         )],
         [ENABLE_$1="$enableval"],
         [AS_IF(
-            [test "x$4" == "xdisable"],
+            [test "x$4" = "xdisable"],
             [ENABLE_$1="yes"],
             [ENABLE_$1="no"]
         )]
     )
-    AM_CONDITIONAL([ENABLE_$1], [test "x$ENABLE_$1" == "xyes"])
+    AM_CONDITIONAL([ENABLE_$1], [test "x$ENABLE_$1" = "xyes"])
     AC_SUBST([ENABLE_$1])
 ])


### PR DESCRIPTION
I had an issue where this theme would not build correctly, and it turned out that dash did not understand the configure script properly.
Unlike bash, not all shells tolerate "==" instead of "=".