### PR TITLE
Firefox urlbar dropdown: improve visibility of links

### DIFF
--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -8,6 +8,8 @@
   -GtkTreeView-horizontal-separator: 4;
   -GtkWidget-text-handle-width: 20;
   -GtkWidget-text-handle-height: 20;
+  -GtkWidget-link-color: #33ccff;
+  -GtkWidget-link-color-visited: #cc66cc;
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
   outline-color: rgba(243, 243, 245, 0.3);


### PR DESCRIPTION
...by raising colour values; use palettes in Firefox ‘about:preferences#content > Colours > Link Colours’ as guide.

#190 #13 

Before:
![vertex-dark_pre_gtk3_link-color_setting](https://cloud.githubusercontent.com/assets/20239223/16546581/940ef514-413e-11e6-858b-0c61ab66c594.png)

After:
![vertex-dark_post_gtk3_link-color_setting](https://cloud.githubusercontent.com/assets/20239223/16546583/9b517edc-413e-11e6-958f-0248334b5816.png)