### PR TITLE
Fix for glitched icon labels when renaming icons in nemo

### DIFF
--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -3967,6 +3967,9 @@ terminal-window scrollbar.vertical slider {
   .nautilus-list-dim-label:selected:focus {
     color: #d9e6fe; }
 
+NemoWindow EelEditableLabel.entry {
+  transition: none; }
+
 .nautilus-window searchbar {
   box-shadow: none;
   border-top: 1px solid #171819; }

--- a/common/gtk-3.0/3.20/gtk-light.css
+++ b/common/gtk-3.0/3.20/gtk-light.css
@@ -3978,6 +3978,9 @@ terminal-window scrollbar.vertical slider {
   .nautilus-list-dim-label:selected:focus {
     color: #d9e6fe; }
 
+NemoWindow EelEditableLabel.entry {
+  transition: none; }
+
 .nautilus-window searchbar {
   box-shadow: none;
   border-top: 1px solid #b9b9b9; }

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -3978,6 +3978,9 @@ terminal-window scrollbar.vertical slider {
   .nautilus-list-dim-label:selected:focus {
     color: #d9e6fe; }
 
+NemoWindow EelEditableLabel.entry {
+  transition: none; }
+
 .nautilus-window searchbar {
   box-shadow: none;
   border-top: 1px solid #b9b9b9; }


### PR DESCRIPTION
An extra CSS rule is needed to make sure desktop and file explorer icon labels display correctly when trying to rename them in nemo.