### PR TITLE
remove 3 deprecated properties in softwarecenter.css

### DIFF
--- a/extra/Ubuntu-Software-Center/softwarecenter.css
+++ b/extra/Ubuntu-Software-Center/softwarecenter.css
@@ -43,9 +43,6 @@
 }
 
 .more-link {
-    -GtkButton-inner-border: 0;
-    -GtkButton-default-border: 0;
-    -GtkButton-default-outside-border: 0;
     background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
     border-color: @borders;


### PR DESCRIPTION
Fix warnings:

```
Gtk-WARNING **: 11:48:31.445: Theme parsing error: softwarecenter.css:49:29: The style property GtkButton:inner-border is deprecated and shouldn't be used anymore. It will be removed in a future version

Gtk-WARNING **: 11:48:31.445: Theme parsing error: softwarecenter.css:50:31: The style property GtkButton:default-border is deprecated and shouldn't be used anymore. It will be removed in a future version

Gtk-WARNING **: 11:48:31.446: Theme parsing error: softwarecenter.css:51:39: The style property GtkButton:default-outside-border is deprecated and shouldn't 
```